### PR TITLE
增加图片下载授权判断，替换两个即将被废弃的canvas方法

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,11 +1,12 @@
 {
-  "pages":[
+  "pages": [
     "pages/index/index"
   ],
-  "window":{
-    "backgroundTextStyle":"light",
+  "window": {
+    "backgroundTextStyle": "light",
     "navigationBarBackgroundColor": "#fff",
     "navigationBarTitleText": "WeChat",
-    "navigationBarTextStyle":"black"
-  }
+    "navigationBarTextStyle": "black"
+  },
+  "sitemapLocation": "sitemap.json"
 }

--- a/miniprogram_dist/index/index.js
+++ b/miniprogram_dist/index/index.js
@@ -31,8 +31,8 @@ const main = {
         if (backgroundColor) {
             // 画面
             this.ctx.save();
-            this.ctx.setGlobalAlpha(opacity);
-            this.ctx.setFillStyle(backgroundColor);
+            this.ctx.globalAlpha = opacity;
+            this.ctx.fillStyle = backgroundColor; 
             if (borderRadius > 0) {
                 // 画圆角矩形
                 this._drawRadiusRect(x, y, blockWidth, height, borderRadius);
@@ -45,7 +45,7 @@ const main = {
         if (borderWidth) {
             // 画线
             this.ctx.save();
-            this.ctx.setGlobalAlpha(opacity);
+            this.ctx.globalAlpha = opacity;
             this.ctx.setStrokeStyle(borderColor);
             this.ctx.setLineWidth(this.toPx(borderWidth));
             if (borderRadius > 0) {
@@ -180,9 +180,9 @@ const handle = {
         this.ctx.save();
         this.ctx.beginPath();
         this.ctx.font = fontStyle + " " + fontWeight + " " + this.toPx(fontSize, true) + "px " + fontFamily
-        this.ctx.setGlobalAlpha(opacity);
+        this.ctx.globalAlpha = opacity;
         // this.ctx.setFontSize(this.toPx(fontSize));
-        this.ctx.setFillStyle(color);
+        this.ctx.fillStyle = color; 
         this.ctx.setTextBaseline(baseLine);
         this.ctx.setTextAlign(textAlign);
         let textWidth = this.toRpx(this.ctx.measureText(text).width);
@@ -454,7 +454,7 @@ Component({
                     // 设置画布底色
                     if (config.backgroundColor) {
                         this.ctx.save();
-                        this.ctx.setFillStyle(config.backgroundColor);
+                        this.ctx.fillStyle = config.backgroundColor;
                         this.ctx.fillRect(0, 0, this.toPx(config.width), this.toPx(height));
                         this.ctx.restore();
                     }

--- a/miniprogram_dist/poster/index.js
+++ b/miniprogram_dist/poster/index.js
@@ -25,6 +25,9 @@ Component({
                 this.trigger('downloadFail', e);
             });
         }
+        this.setData({
+          isCreating: 0, //1为正在创建 防止重复点击 防止在生成过程中重复点击生成
+        })
     },
     methods: {
         trigger(event, data) {
@@ -62,25 +65,98 @@ Component({
             })
         },
         onCreate(reset = false) {
-            !this.data.hideLoading && wx.showLoading({ mask: true, title: '生成中' });
-            return this.downloadResource(typeof reset === 'boolean' && reset).then(() => {
-                !this.data.hideLoading && wx.hideLoading();
-                const poster = this.selectComponent('#poster');
-                poster.create(this.data.config);
-            })
-            .catch((err) => {
-                !this.data.hideLoading && wx.hideLoading();
-                wx.showToast({ icon: 'none', title: err.errMsg || '生成失败' });
-                console.error(err);
-                this.triggerEvent('fail', err);
-            })
+          this.checkSetting();
         },
+      // 自定义修改 检查用户是否授权
+      checkSetting: function () {
+        let that = this;
+        //是否授权
+        wx.getSetting({
+          success: function (res) {
+            let writePhotosAlbum = res.authSetting["scope.writePhotosAlbum"];
+            if (writePhotosAlbum) {
+              //已授权
+              that.creatPic();
+            } else if (writePhotosAlbum != undefined && writePhotosAlbum != true) {
+              //关闭分享弹窗
+              that.triggerEvent('close');
+              //拒绝授权了
+              wx.showModal({
+                title: '',
+                content: '您还未授权保存图片到相册，请确认授权',
+                showCancel: true,
+                cancelText: '取消',
+                confirmText: '确认',
+                success: function (e) {
+                  //点了查看规则
+                  if (e.confirm) {
+                    //针对用户保存图片的时候可能会拒绝授权，再次点击时需要调起授权窗口
+                    that.openSetting();
+                  } else {
+                    //取消
+                  }
+                }
+              })
+            } else {
+              that.creatPic();
+            }
+          }
+        })
+      },
+      // 自定义修改 未授权重新调起授权弹窗
+      openSetting: function () {
+        let that = this;
+        //调起授权弹窗
+        wx.openSetting({
+          success(res) {
+            //同意授权
+            if (res.authSetting["scope.writePhotosAlbum"]) {
+              that.creatPic();
+            }
+          }
+        });
+      },
+      //自定义修改 分离出生成图片方法
+      creatPic: function () {
+        //正在生成
+        let that = this;
+        if (that.data.isCreating) {
+          wx.showToast({
+            title: '图片正在生成中，请稍后再试',
+            icon: 'none'
+          })
+          return;
+        }
+        that.setData({
+          isCreating: 1
+        });
+        !that.data.hideLoading && wx.showLoading({ mask: true, title: '正在生成图片...' });
+        return that.downloadResource(typeof reset === 'boolean' && reset).then(() => {
+          !that.data.hideLoading && wx.hideLoading();
+          const poster = that.selectComponent('#poster');
+          poster.create(that.data.config);
+        })
+          .catch((err) => {
+            !that.data.hideLoading && wx.hideLoading();
+            wx.showToast({ icon: 'none', title: err.errMsg || '生成失败' });
+            that.setData({
+              isCreating: 0
+            })
+            that.triggerEvent('fail', err);
+          })
+      },
         onCreateSuccess(e) {
             const { detail } = e;
+            this.setData({
+              isCreating: 0
+            })
             this.triggerEvent('success', detail);
         },
         onCreateFail(err) {
             console.error(err);
+            this.setData({
+              isCreating: 0
+            })
             this.triggerEvent('fail', err);
         }
     }

--- a/project.config.json
+++ b/project.config.json
@@ -12,9 +12,11 @@
 	},
 	"compileType": "miniprogram",
 	"libVersion": "2.3.0",
-	"appid": "wx637a3fa923864f90",
+	"appid": "wx24e3f6a4ab8d33e4",
 	"projectname": "%E6%B5%B7%E6%8A%A5%E7%BB%84%E4%BB%B6",
 	"scripts": {},
+	"simulatorType": "wechat",
+	"simulatorPluginLibVersion": {},
 	"condition": {
 		"search": {
 			"current": -1,

--- a/sitemap.json
+++ b/sitemap.json
@@ -1,0 +1,7 @@
+{
+  "desc": "关于本文件的更多信息，请参考文档 https://developers.weixin.qq.com/miniprogram/dev/framework/sitemap.html",
+  "rules": [{
+  "action": "allow",
+  "page": "*"
+  }]
+}


### PR DESCRIPTION
1、增加图片下载授权判断，判断如下：如果受过权直接执行生成图片的方法，如果拒绝了授权会弹窗提示授权用户可点击确认跳进授权页面进行授权，如果没有进行过授权则会调用微信内置授权方法。
2、增加图片下载生成状态的isCreating变量，1为生成中，0为已结束，防止用户生成中重复调用。
3、替换两个即将被废弃的canvas方法