### PR TITLE
fixed:剔除掉http://tmp/路径以支持微信临时文件;

### DIFF
--- a/miniprogram_dist/index/index.js
+++ b/miniprogram_dist/index/index.js
@@ -315,7 +315,10 @@ const helper = {
      */
     _downImage(imageUrl) {
         return new Promise((resolve, reject) => {
-            if (/^http/.test(imageUrl) && !new RegExp(wx.env.USER_DATA_PATH).test(imageUrl)) {
+            if(/^http(s)?:\/\/tmp\//.test(imageUrl)){
+                //剔除掉http://tmp/路径以支持微信临时文件;
+                resolve(imageUrl);
+            }else if (/^http/.test(imageUrl) && !new RegExp(wx.env.USER_DATA_PATH).test(imageUrl)) {
                 wx.downloadFile({
                     url: this._mapHttpToHttps(imageUrl),
                     success: (res) => {


### PR DESCRIPTION
### iamges支持微信临时图片
> 因用户上传的图片为临时图片，无法被添加到画布中，需要针对临时文件单独处理；
对tmp临时路径单独处理，若匹配则直接resolve;